### PR TITLE
Add bench to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "bench": "^0.3.6",
     "tap": "~0.3.0"
   },
   "scripts": {


### PR DESCRIPTION
Cannot find module `bench` while running `node bench`
```
Error: Cannot find module 'bench'
    at Function.Module._resolveFilename (module.js:527:15)
    at Function.Module._load (module.js:476:23)
    at Module.require (module.js:568:17)
    at require (internal/module.js:11:18)
    at start (~/sigmund/bench.js:41:3)
    at Timeout._onTimeout (~/sigmund/bench.js:19:5)
    at ontimeout (timers.js:469:11)
    at tryOnTimeout (timers.js:304:5)
    at Timer.listOnTimeout (timers.js:264:5)
```